### PR TITLE
Streamline FileReference constructor

### DIFF
--- a/Classes/FileReference.php
+++ b/Classes/FileReference.php
@@ -37,18 +37,18 @@ class FileReference extends \TYPO3\CMS\Core\Resource\FileReference
 
 		$file = Environment::getPublicPath() . '/' . $this->publicUrl;
 
-		if (!file_exists($file)) {
-			if (isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['fal']['loadFilesFromRemoteIfMissing']) &&
-				$GLOBALS['TYPO3_CONF_VARS']['SYS']['fal']['loadFilesFromRemoteIfMissing']) {
-				$this->loadFileFromRemote();
-			}
+		if (file_exists($file)) {
+			return;
 		}
 
-		if (!file_exists($file)) {
-			if (isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['fal']['fakeFilesIfMissing']) &&
-				$GLOBALS['TYPO3_CONF_VARS']['SYS']['fal']['fakeFilesIfMissing']) {
-				$this->createFakeFile();
-			}
+		if (isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['fal']['loadFilesFromRemoteIfMissing']) &&
+			$GLOBALS['TYPO3_CONF_VARS']['SYS']['fal']['loadFilesFromRemoteIfMissing']) {
+			$this->loadFileFromRemote();
+		}
+
+		if (isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['fal']['fakeFilesIfMissing']) &&
+			$GLOBALS['TYPO3_CONF_VARS']['SYS']['fal']['fakeFilesIfMissing']) {
+			$this->createFakeFile();
 		}
 	}
 


### PR DESCRIPTION
Instead of checking for each case whether the file exists it is done once beforehand. If the file exists no further code will be executed.